### PR TITLE
Add support for GPIO control on the YKUSH3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ $ python setup.py install
 
 ```bash
 $ python pykush.py -h
-usage: pykush_hidapi.py [-h] [-s SERIAL]
-                        (-l | -u [UP [UP ...]] | -d [DOWN [DOWN ...]] | -p)
+usage: pykush.py [-h] [-s SERIAL]
+                 (-l | -u [UP [UP ...]] | -d [DOWN [DOWN ...]] | -r READ | -w WRITE WRITE | -p)
 
 Yepkit YKUSH command line tool.
 
@@ -84,8 +84,11 @@ optional arguments:
                         the downstream port numbers to power up, none means
                         all
   -d [DOWN [DOWN ...]], --down [DOWN [DOWN ...]]
-                        the downstream port numbers to power down, none
-                        means all
+                        the downstream port numbers to power down, none means
+                        all
+  -r READ, --read READ  the GPIO pin to read from
+  -w WRITE WRITE, --write WRITE WRITE
+                        the GPIO pin to write to
   -p, --persist         make the current running configuration persistent
                         across reboots (only supported on devices with
                         firmware v2.0 and above)

--- a/pykush/pykush.py
+++ b/pykush/pykush.py
@@ -323,7 +323,7 @@ def main():
     group.add_argument('-d', '--down', type=int, nargs='*',
                        help='the downstream port numbers to power down, none means all')
     group.add_argument('-r', '--read', type=int, help='the GPIO pin to read from')
-    group.add_argument('-w', '--write', type=int, nargs=2, help='the GPIO pin to write to')
+    group.add_argument('-w', '--write', type=int, nargs=2, help='the GPIO pin to write to and the value to write')
     group.add_argument('-p', '--persist', default=None,
                        help='make the current running configuration persistent across reboots (only supported on devices with firmware v2.0 and above)',
                        action='store_true')

--- a/pykush/pykush.py
+++ b/pykush/pykush.py
@@ -216,6 +216,9 @@ class YKUSH(object):
             if status == YKUSH_PROTO_OK_STATUS:
                 # YKUSH recognized the request
                 self._downstream_port_count = count
+            elif self._devhandle.get_product_string() == 'YKUSH3':
+                # YKUSH3 has an additional power-only port
+                self._downstream_port_count = 4
             else:
                 # original YKUSH port count
                 self._downstream_port_count = 3


### PR DESCRIPTION
This commit adds:

* -r/--read options and a get_gpio method to read GPIO pins
* -w/--write options and a set_gpio method to write to GPIO pins

These options are only valid on the YKUSH3 and should fail with an error
on other models (though I have not tested them).