### PR TITLE
Updated setup and __init__.py to make repo compatible with pypi

### DIFF
--- a/pykush/__init__.py
+++ b/pykush/__init__.py
@@ -1,0 +1,1 @@
+from .pykush import *

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+description-file=README.md
+license_files=LICENSE

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,14 @@ from __future__ import unicode_literals
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.5'
 
 setup(
-    name='pykush',
+    name='yepkit-pykush',
     version=version,
     description='Yepkit YKUSH Python API and command line tool',
     long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     author='ckuesters',
     author_email='ckuesters@yepkit.com',
     license='MIT',


### PR DESCRIPTION
1) Change of__init__.py was necessary to avoid the case of "from pykush.pykush import YKUSH".

2) Setup change:

- Change the name since "pykush" was already a repository on pypi by another author.
- Change to description content type to make it compatible with pypi
- Change to version number due to experimenting with pypi compatibility. The versions 0.3.0 - 0.3.4 did not behave according to the documentation, due to issue 1)

The pypi package can be found at: 
https://pypi.org/project/yepkit-pykush/

Please contact me if you have any questions, propositions or you would like access to the pypi package.