### PR TITLE
Add support for 5V power output control on the YKUSH3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.4.0'
 
 setup(
     name='pykush',


### PR DESCRIPTION
Noticed that there was not yet any control for the switchable 5V power output available on the YKUSH3.  I added a couple options and methods related to this feature.